### PR TITLE
Build on linux

### DIFF
--- a/src/ezsockets.cpp
+++ b/src/ezsockets.cpp
@@ -215,16 +215,16 @@ bool EzSockets::listen()
 
 void EzSockets::setBlocking(bool b)
 {
-#if defined(WIN32)
 	ezs_internal *data = (ezs_internal*)(this->opaque);
+#if defined(WIN32)
 	u_long iMode = 0;
 	if (!b)	iMode = 1;
 	ioctlsocket(data->sock, FIONBIO, &iMode);
 #else
-	const int flags = fcntl(sock, F_GETFL, 0);
+	const int flags = fcntl(data->sock, F_GETFL, 0);
 	if ((flags & O_NONBLOCK) && !b) { return; }
 	if (!(flags & O_NONBLOCK) && b) { return; }
-	fcntl(sock, F_SETFL, (b ? flags ^ O_NONBLOCK : flags | O_NONBLOCK));
+	fcntl(data->sock, F_SETFL, (b ? flags ^ O_NONBLOCK : flags | O_NONBLOCK));
 #endif
 	blocking = b;
 }

--- a/src/io/Python23IO.h
+++ b/src/io/Python23IO.h
@@ -105,7 +105,7 @@ private:
 	static uint8_t hxdb_vbaud_rate;// = 0x03; //this is 2 on p2io
 	static uint8_t extio_vcom_port;// = 0x00;//p2io only
 	static uint8_t extio_vbaud_rate;// = 0x03;//p2io only
-	static uint8_t Python23IO::hdxb_dev_id; // if user connects ONLY HDXB this they can change this but really they shouldn't
+	static uint8_t hdxb_dev_id; // if user connects ONLY HDXB this they can change this but really they shouldn't
 	static const int interrupt_ep = 0x83;
 	static const int bulk_write_to_ep = 0x02;
 	static const int bulk_read_from_ep = 0x81;
@@ -113,11 +113,11 @@ private:
 	static const uint16_t python3io_PRODUCT_ID[2];// = { 0x5731, 0x8008 };
 	static const uint16_t python2io_VENDOR_ID[1];// = { 0x0000 };
 	static const uint16_t python2io_PRODUCT_ID[1];// = { 0x7305 };
-	static Preference<PSTRING> Python23IO::m_COM4PORT;
-	static Preference<PSTRING> Python23IO::m_sP23IOMode;
-	static Preference<bool> Python23IO::m_bP2IOEXTIO;
-	static Preference<int> Python23IO::m_iP2IO_HDXB_DEV_ID;
-	
+	static Preference<PSTRING> m_COM4PORT;
+	static Preference<PSTRING> m_sP23IOMode;
+	static Preference<bool> m_bP2IOEXTIO;
+	static Preference<int> m_iP2IO_HDXB_DEV_ID;
+
 
 };
 


### PR DESCRIPTION
Had to make some minimal changes to get this to build in Ubuntu.

After some testing on my machine; input does work on a P2IO device.  Lights however, still don't seem to be working.

I re-enabled a logging call in `src\io\Python23IO.cpp:1068` but it only seems to be sending the same data repeatedly:

```
00:03.222: Checking Python23IO mode...
00:03.222: Python23IO mode Type set to P2IO without HDXB device.
00:03.271: Python23IO P2IO Driver:: Connected to index 0
00:03.271: Python23IO Flushing Read buffer. Expect it to give up
00:05.275: Python23IO must have given up sending data we need (0/3 bytes)
00:05.280: Python23IO Flushing Read buffer. Expect it to give up
00:07.284: Python23IO must have given up sending data we need (0/3 bytes)
00:07.284: **************Python23IO board specs: SDP2IO isp2io:1 hashdxb:0 hasvextio:1
00:07.284: Opened Python2/3 IO USB board.
00:07.284: Starting thread: Python23IO USB Interrupt thread
00:07.285: detect Python23IO bulk thread.
00:07.285: Starting thread: Python23IO USB Bulk thread
...<snip>...
00:07.313: Python23IO driver Sending P2IO light message: AA 04 00 24 00 F3
00:07.349: Python23IO driver Sending P2IO light message: AA 04 00 24 00 F3
...<snip>...
01:48.592: Python23IO driver Sending P2IO light message: AA 04 00 24 00 F3
01:48.627: Python23IO driver Sending P2IO light message: AA 04 00 24 00 F3
```

In fact, I've never seen it log anything other than those values.

Maybe I've got it configured incorrectly, here's the relevant bits from my `Preferences.ini` file:

```ini
LightsDriver=EXTIO
Python23IO_HDXB_DEV_ID=3
Python23IO_HDXB_PORT=
Python23IO_Mode=SDP2IO
Python23IO_P2IO_EXTIO=1
```